### PR TITLE
donation-notification: add slack notification

### DIFF
--- a/dbwrapper/views.py
+++ b/dbwrapper/views.py
@@ -105,7 +105,7 @@ class DonationFormView(View):
                         donation.save()
 
                         logger.info("Preparing to send e-mail receipt...")
-                        dp.send_email_receipt(donor, donation)
+                        dp.notify_donation(donor, donation)
 
                         return render(request, 'dbwrapper/successful_donation.html')
                     else:


### PR DESCRIPTION
Maybe there's a better way to do that, but for now, it's what I got.

There are somethings necessary to be created manually:
 - Slack token: go here: https://api.slack.com/apps and create an app in the workspace to be notified
   - click in the app created and go to: https://api.slack.com/apps/{app_id}/oauth?
   - in 'Scopes', give the permissions `channel:read` and `chat:write:bot `
 - Given the token, access: https://slack.com/api/channels.list?token={token} and search the id of the slack channel to be notified
 - Save these two informations as environment variables `SLACK_TOKEN` and `SLACK_CHANNEL`

Tested it by creating my own slack workplace for tests.

As of now, the notification will be triggered only in the 'happy flow' when the transaction actually completes and the receipt is sent to the donor.
